### PR TITLE
Modify source script to be more portable.

### DIFF
--- a/bin/st
+++ b/bin/st
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -T
+#!perl -T
 
 use strict;
 use warnings;


### PR DESCRIPTION
MakeMaker will replace the '#!perl -T' line w/the builders perl location, properly expanded when you run perl Makefile.PL -- check in generated ./blib/script/st to verify, and when you make install -- it will be the proper perl path.  
