### PR TITLE
Validate fixes

### DIFF
--- a/lib/App/St.pm
+++ b/lib/App/St.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 #use bignum;
+use Scalar::Util qw(looks_like_number);
 
 our $VERSION = '1.1.3';
 
@@ -46,15 +47,8 @@ sub new {
 }
 
 sub validate {
-  my ($self, $num) = @_;
-
-  return ($num =~ m{^
-    [+-]?
-    (?: \. ? [0-9]+
-      | [0-9]+ \. [0-9]*
-      | [0-9]* \. ? [0-9]+ [Ee] [+-]? [0-9]+
-    )
-  $}x);
+  my (undef, $num) = @_;
+  return looks_like_number($num);
 }
 
 sub process {

--- a/lib/App/St.pm
+++ b/lib/App/St.pm
@@ -54,8 +54,6 @@ sub validate {
 sub process {
   my ($self, $num) = @_;
 
-  die "Invalid input '$num'\n" if !$self->validate($num);
-
   $self->{N}++;
 
   $self->{sum} += $num;

--- a/script/st
+++ b/script/st
@@ -8,6 +8,7 @@ use warnings;
 use Data::Dumper;
 use Getopt::Long;
 use Pod::Usage;
+use Scalar::Util qw(looks_like_number);
 
 use App::St;
 
@@ -71,11 +72,12 @@ my %special_parameters = map { $_ => $opt{$_} } grep { exists $opt{$_} } qw/perc
 my $st = App::St->new(%config, %special_parameters);
 
 my $n = 0;
+
 while (my $num = <>) {
   chomp $num;
 
   $n++;
-  if (!$st->validate($num)) {
+  if (!looks_like_number($num)) {
       my $err = "Invalid value '$num' on input line $.\n";
       if ($opt{strict}) {
         die $err;

--- a/script/st
+++ b/script/st
@@ -71,12 +71,9 @@ my %special_parameters = map { $_ => $opt{$_} } grep { exists $opt{$_} } qw/perc
 
 my $st = App::St->new(%config, %special_parameters);
 
-my $n = 0;
-
 while (my $num = <>) {
   chomp $num;
 
-  $n++;
   if (!looks_like_number($num)) {
       my $err = "Invalid value '$num' on input line $.\n";
       if ($opt{strict}) {


### PR DESCRIPTION
This change makes `st` a bit quicker for large inputs. The main boost comes from de-duplicating the `validate` check for every number. The validation check is also replaced with Scalar::Util's `looks_like_number`, which passes the existing test suite, is part of core, and is implemented in C.

This change, as it is now, would require a version bump on the library since previously, `process` would die on invalid input. This change assumes the caller has validated the input. It should be straightforward to avoid that if necessary.

I've included some simple runs on a 40mb file showing the before and after below. The run time for this file was reduced to 14s, originally taking 21s. Both times were taken after multiple runs of tests to account for page caches being warm etc. 

Current `st`:

```
-bash-4.2$ time st --complete /tmp/input.txt
N	min	q1	median	q3	max	sum	mean	stddev	stderrvariance
4.45998e+06	0.002401	0.00371	0.004048	0.004653	0.069798	28189.6	0.00632058	0.00852295	4.03574e-06	7.26406e-05

real	0m21.341s
user	0m20.551s
sys	0m0.790s
```

Proposed:

```
-bash-4.2$ time st --complete /tmp/input.txt
N	min	q1	median	q3	max	sum	mean	stddev	stderrvariance
4.45998e+06	0.002401	0.00371	0.004048	0.004653	0.069798	28189.6	0.00632058	0.00852295	4.03574e-06	7.26406e-05

real	0m14.079s
user	0m13.255s
sys	0m0.823s
```